### PR TITLE
Account for not-unique source masked values

### DIFF
--- a/rio_hist/match.py
+++ b/rio_hist/match.py
@@ -37,6 +37,15 @@ def histogram_match(source, reference, match_proportion=1.0):
     else:
         logger.debug("ref is unmasked, raveling")
         reference = reference.ravel()
+    
+    # if user inputs source array with masked nodata val of 0,
+    # machine epsilon will create multiple nodata vals and
+    # mess up our subsequent mask_index system. To circumvent this,
+    # replace all masked source values with nan
+    if np.ma.is_masked(source):
+        logger.debug("source is masked; replacing mask vals with nan")
+        source = np.ma.masked_array(np.where(source.mask,np.nan,source),
+                                    mask=source.mask)
 
     # get the set of unique pixel values
     # and their corresponding indices and counts


### PR DESCRIPTION
Suppose a user inputs an array where masked values are not all unique (e.g. user is matching histograms for .tif red raster band with nodata value of 0. When rastertio.open() reads the .tif, machine epsilon may code some zeros a little bit off, like say 0.00000000001. Then the mask will cover 0 and 0.00000000001). Then, before the insertion of this edit, mask_index[0] would contain more than one value, and everything breaks. My edit replaces all masked values with np.nan up front to ensure np.unique (line 53) records only one masked value, thus preserving the mask_index[0] system below.